### PR TITLE
updated detection of Mongoid major version

### DIFF
--- a/lib/mongoid/max/denormalize.rb
+++ b/lib/mongoid/max/denormalize.rb
@@ -39,10 +39,10 @@ module Mongoid
         end
 
         def mongoid3
-          Mongoid::VERSION =~ /\A3\./
+          defined? Moped
         end
         def mongoid2
-          Mongoid::VERSION =~ /\A2\./
+          defined? Mongo
         end
 
         def denormalize_update_all(conditions, updates)


### PR DESCRIPTION
from regex to checking what constants are defined: Moped for 3.x, and Mongo for 2.x
